### PR TITLE
update provider validation to allow a list of structs or a single struct

### DIFF
--- a/1.4/core/core.cue
+++ b/1.4/core/core.cue
@@ -53,10 +53,15 @@ import (
 }
 
 // https://developer.hashicorp.com/terraform/language/v1.4.x/providers/configuration
-#Provider: {
-	alias?: string
-	...
-}
+#Provider: [...{
+		alias?: string
+		...
+  }
+	] | {
+		alias?: string
+		...
+	}
+
 
 // https://developer.hashicorp.com/terraform/language/v1.4.x/values/variables
 #Variable: {


### PR DESCRIPTION
This validation allows the use of a list of structs or a single struct for provider definition. This means we can now define multiple instances of the same provider using standard Cue syntax, with no risk  E.G.:

```
provider: azurerm: [
  {
    subscription_id: "USER INPUT SUBSCRIPTION"
    features: {}
  },
  {
    alias: "othersub"
    subscription_id: "SUBSCRIPTION"
    features: {}
  }
] 
```

Previously in my testing defining multiple instances of the same provider would cause the two providers to coalesce into a single instance if the subscription ID was the same and no alias is provided on the other instance. In our use case subscription 1 is derived from user input. Subscription 2 is a statically defined provider used to read data from some pre-defined azure resources. Subscription 1 and Subscription 2 may, in theory be the same subscription but must remain separate providers due to alias usage. This change preserves the said configuration of multiple provider instances.

Without the ability to use a list of structs for providers in the event that "USER INPUT SUBSCRIPTION" is equal to "SUBSCRIPTION" you end up rendering the above code down to this:

```
    "provider": {
        "azurerm":
            {
                "alias": "othersub",
                "subscription_id": "SUBSCRIPTION",
                "features": {}
            }
    },
```

With my proposed changes it becomes:

```
    "provider": {
        "azurerm": [
            {
                "subscription_id": "SUBSCRIPTION",
                "features": {}
            },
            {
                "alias": "othersub",
                "subscription_id": "SUBSCRIPTION",
                "features": {}
            }
        ]
    },
```